### PR TITLE
[PRIORITY] fixed base model typos in fields.

### DIFF
--- a/backend/base/models.py
+++ b/backend/base/models.py
@@ -7,8 +7,8 @@ from django.utils import timezone
 class TimestampedModel(models.Model):
     """Timestamped model."""
 
-    create_at = models.DateTimeField(default=timezone.now)
-    update_at = models.DateTimeField(default=timezone.now)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(default=timezone.now)
 
     class Meta:
         """Meta class."""


### PR DESCRIPTION
Base model fields `create_at` and `update_at` were supposed to be `created_at` and `updated_at` to be used in place of the `created_at` and `updated_at` fields that will be required on the subsequent models