### PR TITLE
speakers crud

### DIFF
--- a/speakwise/speakwise/config/urls.py
+++ b/speakwise/speakwise/config/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("api/events/", include("speakwise.events.urls", namespace="events")),
     path("api/talks/", include("speakwise.talks.urls", namespace="talks")),
+    path("api/speakers/", include("speakwise.speakers.urls", namespace="speakers")),
     # Media files
     *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),
 ]

--- a/speakwise/speakwise/speakwise/events/models.py
+++ b/speakwise/speakwise/speakwise/events/models.py
@@ -69,3 +69,6 @@ class Session(TimestampedModel):
 
     # TODO: Add speaker field
     speaker = models.CharField(max_length=255, null=True)
+
+    def __str__(self):
+        return self.name

--- a/speakwise/speakwise/speakwise/speakers/models.py
+++ b/speakwise/speakwise/speakwise/speakers/models.py
@@ -2,7 +2,6 @@
 
 from base.models import TimestampedModel
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
 

--- a/speakwise/speakwise/speakwise/speakers/serializers.py
+++ b/speakwise/speakwise/speakwise/speakers/serializers.py
@@ -1,6 +1,9 @@
 """Speakers serializers."""
 
 from rest_framework.serializers import ModelSerializer
+
+from speakwise.base.validators import validate_date_time_values
+
 from .models import Speaker
 
 
@@ -11,4 +14,11 @@ class SpeakerSerializer(ModelSerializer):
         """Meta class."""
 
         model = Speaker
-        fields = "__all__"
+        exclude = ["created_at", "updated_at"]
+
+    def validate(self, data):
+        validate_date_time_values(
+            data.get("start_date_time"),
+            data.get("end_date_time"),
+        )
+        return data

--- a/speakwise/speakwise/speakwise/speakers/tests.py
+++ b/speakwise/speakwise/speakwise/speakers/tests.py
@@ -1,10 +1,11 @@
 """Speakers app tests."""
 
 from django.contrib.auth import get_user_model
-from django.urls import reverse
 from django.test import TestCase
-from rest_framework.test import APITestCase
+from django.urls import reverse
 from rest_framework import status
+from rest_framework.test import APITestCase
+
 from .models import Speaker
 from .serializers import SpeakerSerializer
 
@@ -17,7 +18,8 @@ class SpeakerModelTest(TestCase):
     def setUp(self):
         """Set up test data."""
         self.user = User.objects.create_user(
-            username="testuser", password="password123"
+            username="testuser",
+            password="password123",
         )
         self.speaker = Speaker.objects.create(
             user_id=self.user,
@@ -43,7 +45,9 @@ class SpeakerSerializerTest(TestCase):
     def setUp(self):
         """Set up test data."""
         self.user = User.objects.create_user(
-            username="testuser", password="password123"
+            username="testuser",
+            password="password123",
+            email="user@mail.com",
         )
         self.speaker_data = {
             "user_id": self.user,
@@ -86,10 +90,12 @@ class SpeakerAPITest(APITestCase):
     def setUp(self):
         """Set up test data."""
         self.user = User.objects.create_user(
-            username="testuser", password="password123"
+            username="testuser",
+            password="password123",
         )
         self.user2 = User.objects.create_user(
-            username="testsuser", password="password123"
+            username="testsuser",
+            password="password123",
         )
         self.client.login(username="testuser", password="password123")
         self.speaker = Speaker.objects.create(

--- a/speakwise/speakwise/speakwise/speakers/urls.py
+++ b/speakwise/speakwise/speakwise/speakers/urls.py
@@ -5,9 +5,13 @@ from django.urls import path
 from .views import RetrieveUpdateDestroySpeakerView
 from .views import SpeakerListCreateView
 
+app_name = "speakers"
+
 urlpatterns = [
     path("", SpeakerListCreateView.as_view(), name="list_create_speakers"),
     path(
-        "<int:pk>/", RetrieveUpdateDestroySpeakerView.as_view(), name="speaker_detail"
+        "<int:pk>/",
+        RetrieveUpdateDestroySpeakerView.as_view(),
+        name="speaker_detail",
     ),
 ]

--- a/speakwise/speakwise/speakwise/speakers/views.py
+++ b/speakwise/speakwise/speakwise/speakers/views.py
@@ -1,5 +1,6 @@
 """Speaker views."""
 
+from drf_spectacular.utils import extend_schema
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 
@@ -8,6 +9,7 @@ from .models import Speaker
 from .serializers import SpeakerSerializer
 
 
+@extend_schema(request=SpeakerSerializer, responses=SpeakerSerializer(many=True))
 class SpeakerListCreateView(generics.ListCreateAPIView):
     """Speaker list and create api endpoint."""
 
@@ -16,6 +18,7 @@ class SpeakerListCreateView(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
 
 
+@extend_schema(responses={200, SpeakerSerializer})
 class RetrieveUpdateDestroySpeakerView(generics.RetrieveUpdateDestroyAPIView):
     """retrieve, delete and update endpoint for speakers."""
 

--- a/speakwise/speakwise/speakwise/talks/tests.py
+++ b/speakwise/speakwise/speakwise/talks/tests.py
@@ -19,8 +19,7 @@ class TalksModelTest(TestCase):
 
     def setUp(self):
         """Set up the test."""
-        self.user = User.objects.create_user(
-            username="testuser", password="testpass")
+        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.event = Event.objects.create(
             title="Test Event",
             start_date=datetime.now(),
@@ -53,8 +52,7 @@ class TalksAPITest(TestCase):
     def setUp(self):
         """Set up the test."""
         self.client = APIClient()
-        self.user = User.objects.create_user(
-            username="testuser", password="testpass")
+        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.event = Event.objects.create(
             title="Test Event",
             start_date=datetime.now(),  # Provide a value for start_date
@@ -76,8 +74,7 @@ class TalksAPITest(TestCase):
             end_time=datetime.now() + timedelta(hours=1),
         )
         self.talk.speaker_id.add(self.speaker)
-        self.talk_url = reverse(
-            "talk-retrieve-update-destroy", args=[self.talk.id])
+        self.talk_url = reverse("talk-retrieve-update-destroy", args=[self.talk.id])
         self.talk_list_url = reverse("talk-list-create")
 
     def test_list_talks(self):
@@ -101,8 +98,7 @@ class TalksAPITest(TestCase):
         response = self.client.post(self.talk_list_url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Talks.objects.count(), 2)
-        self.assertEqual(Talks.objects.get(
-            id=response.data["id"]).title, "New Talk")
+        self.assertEqual(Talks.objects.get(id=response.data["id"]).title, "New Talk")
 
     def test_retrieve_talk(self):
         """Test the retrieval of a talk."""


### PR DESCRIPTION
# Info

This PR  introduces the crud endpoints for speakers.

Speakers tests are failing, which is expected and noticed because authentication is not yet implemented and user model is required to test speakers.

A ticket is created to fix that in the future.