### PR TITLE
exclude teams from Team social serializer

### DIFF
--- a/speakwise/speakwise/speakwise/teams/serializers.py
+++ b/speakwise/speakwise/speakwise/teams/serializers.py
@@ -9,7 +9,7 @@ class TeamSocialSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TeamSocial
-        exclude = ["created_at", "updated_at"]
+        exclude = ["created_at", "updated_at", "team"]
 
 
 class TeamMemberSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
The previous version will request for team member id in the social model but this will exclude that, allowing you to only add the social media links.
